### PR TITLE
feat(fields): stream _source when no fields were specified

### DIFF
--- a/lib/elasticsearch-stream.js
+++ b/lib/elasticsearch-stream.js
@@ -42,7 +42,12 @@ LibElasticasearchScrollStream.prototype._read = function() {
     }
 
     response.hits.hits.forEach(function(hit) {
-      self.push(JSON.stringify(hit.fields));
+      if(hit.fields) {
+        self.push(JSON.stringify(hit.fields));
+      } else {
+        self.push(JSON.stringify(hit._source));
+      }
+
       self._counter++;
     });
 


### PR DESCRIPTION
I required the full objects to be passed to the stream and I didn't want to specify all the fields so I changed the output to only push the fields when provided and otherwise stream the full source.
