### PR TITLE
fix: add condition to properly pass scroll id ro elastic client

### DIFF
--- a/lib/elasticsearch-stream.js
+++ b/lib/elasticsearch-stream.js
@@ -1,5 +1,6 @@
 const { Readable } = require('stream')
 
+const MAX_URL_LENGTH = 2000;
 /**
  * LibElasticsearchScrollStream
  *
@@ -53,7 +54,11 @@ class LibElasticsearchScrollStream extends Readable {
     })
 
     if (this._total !== this._counter && !this._forceClose) {
-      this._client.scroll({ scroll: this._options.scroll, scroll_id: body._scroll_id }, this.getMoreUntilDone)
+      if (body._scroll_id.length > MAX_URL_LENGTH) {
+        this._client.scroll({ body: { scroll: this._options.scroll, scroll_id: body._scroll_id } }, this.getMoreUntilDone)
+      } else {
+        this._client.scroll({ scroll: this._options.scroll, scroll_id: body._scroll_id }, this.getMoreUntilDone)
+      }
     } else {
       // clearScroll for the current _scroll_id
       this._client.clearScroll({ scrollId: [body._scroll_id] }, (err, res) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-scroll-stream",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Elasticsearch Scroll query results as a Stream",
   "repository": {
     "type": "git",


### PR DESCRIPTION
if search is done over several indexes with many shard, scroll id is getting longer than allowed URI size, in this case we need to use POST /scroll in elastic client, not GET. see https://github.com/elastic/elasticsearch-js/blob/3942ed722cc15b63a05859fd46ebea6595741ceb/api/api/scroll.js#L89 